### PR TITLE
byDesign Fixes

### DIFF
--- a/modules/bydesign/app/controllers/bydesign/dataanalysis/DataAnalysis.java
+++ b/modules/bydesign/app/controllers/bydesign/dataanalysis/DataAnalysis.java
@@ -13,6 +13,7 @@ import play.mvc.Controller;
 import play.mvc.Http.MultipartFormData;
 import play.mvc.Http.MultipartFormData.FilePart;
 import play.mvc.Result;
+import utils.bydesign.dataanalysis.ErrorKind;
 import views.html.bydesign.dataanalysis.dataanalysis;
 
 /**

--- a/modules/bydesign/app/controllers/bydesign/dataanalysis/DataAnalysis.java
+++ b/modules/bydesign/app/controllers/bydesign/dataanalysis/DataAnalysis.java
@@ -103,7 +103,7 @@ public class DataAnalysis extends Controller {
 
                 // Only deal with CSV files
                 String contentType = idFile.getContentType();
-                if (!contentType.equals("application/vnd.ms-excel") || !extension.equals(".csv")) {
+                if (!isValidInput(contentType, extension)) {
                     // Make sure that we render the error alert and
                     // don't display a file name as the file we are currently
                     // analyzing.
@@ -187,6 +187,28 @@ public class DataAnalysis extends Controller {
         }
 
         return userEventsMap;
+    }
+
+    /**
+     * <p>This performs basic checks on the input file.</p>
+     *
+     * @param contentType The content type specified by the request.
+     * @param extension The file extension.
+     *
+     * @return {@code true} if it is a valid input file, {@code false} otherwise.
+     */
+    private boolean isValidInput(String contentType, String extension) {
+        // Check to see if it is a ".csv" extension
+        boolean result = extension.equals(".csv");
+
+        // Only check the content type if it is a csv file.
+        if (result) {
+            // Check to see if the content type is either "application/vnd.ms-excel"
+            // if the client is using Windows or "text/csv" on MacOS/Linux.
+            result = contentType.equals("application/vnd.ms-excel") || contentType.equals("text/csv");
+        }
+
+        return result;
     }
 
     /**

--- a/modules/bydesign/app/utils/bydesign/dataanalysis/ErrorKind.java
+++ b/modules/bydesign/app/utils/bydesign/dataanalysis/ErrorKind.java
@@ -1,4 +1,4 @@
-package controllers.bydesign.dataanalysis;
+package utils.bydesign.dataanalysis;
 
 /**
  * <p>This file contains the various different errors we might encounter during

--- a/modules/bydesign/app/views/bydesign/dataanalysis/dataanalysis.scala.html
+++ b/modules/bydesign/app/views/bydesign/dataanalysis/dataanalysis.scala.html
@@ -1,9 +1,9 @@
-@import controllers.bydesign.dataanalysis.ErrorKind
 @import helper._
 @import java.lang
 @import java.util
 @import models.common.database.ByDesignEvent
 @import models.common.database.User
+@import utils.bydesign.dataanalysis.ErrorKind
 
 @(currentUser: User, selectedFilename: lang.String, errorKind: ErrorKind,
         eventsMap: util.Map[lang.Long, util.List[ByDesignEvent]], dateGenerated: util.Date)


### PR DESCRIPTION
This addresses the issue that the application fails to retrieve data on MacOS/Linux. The `Content-Type` is different in Windows vs. MacOS/Linux. In Windows it is `application/vnd.ms-excel`. while MacOS/Linux sends `text/csv`. 

`ErrorKind` is not a `controller`, so it has been moved to a separate `utils` package.